### PR TITLE
Added support for dmaker.fan.p5 model

### DIFF
--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -89,13 +89,13 @@ class FanXiaomi extends HTMLElement {
                         newSpeed = speed_list[1]
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-2-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-2-box-outline") {
-                        newSpeed = speed_list['Level 3']
+                        newSpeed = speed_list[2]
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-3-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-3-box-outline") {
-                        newSpeed = speed_list['Level 4']
+                        newSpeed = speed_list[3]
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-4-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-4-box-outline") {
-                        if speed_list[5] === undefined {
+                        if (speed_list[5] === undefined) {
                             newSpeed = speed_list[0]
                             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
                         } else {
@@ -103,7 +103,7 @@ class FanXiaomi extends HTMLElement {
                             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-5-box-outline"></iron-icon>'
                         }
                     } else if (icon.getAttribute('icon') == "mdi:numeric-5-box-outline") {
-                        newSpeed = speed_list['Level 1']
+                        newSpeed = speed_list[0]
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
                     } else {
                         this.log('Error setting fan speed')
@@ -436,8 +436,8 @@ Natural
         }
         let direct_speed_int = Number(direct_speed)
         
-        if (model === 'dmaker.fan.p5') { //p5 does not report direct_speed and natural_speed
-            direct_speed_int = speed_list[int(speed[-1])-1] //speed contains "Level 1" value
+        if (model === 'dmaker.fan.p5') { //p5 does not report direct_speed and natural_speed            
+            direct_speed_int = speed_list[parseInt(speed[speed.length-1])-1] //speed contains "Level 1" value
             if (mode === 'nature') {
                 natural_speed = true
             } else if (mode === 'normal') {

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -437,7 +437,7 @@ Natural
         let direct_speed_int = Number(direct_speed)
         
         if (model === 'dmaker.fan.p5') { //p5 does not report direct_speed and natural_speed
-            direct_speed_int = speed_list[speed]
+            direct_speed_int = speed_list[int(speed[-1])-1] //speed contains "Level 1" value
             if (mode === 'nature') {
                 natural_speed = true
             } else if (mode === 'normal') {
@@ -447,11 +447,11 @@ Natural
         
         if (direct_speed_int <= speed_list[0]) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
-        } else if (direct_speed_int <= speed_list['Level 2']) {
+        } else if (direct_speed_int <= speed_list[1]) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-2-box-outline"></iron-icon>'
-        } else if (direct_speed_int <= speed_list['Level 3']) {
+        } else if (direct_speed_int <= speed_list[2]) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-3-box-outline"></iron-icon>'
-        } else if (direct_speed_int <= speed_list['Level 4']) {
+        } else if (direct_speed_int <= speed_list[3]) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-4-box-outline"></iron-icon>'
         } else {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-5-box-outline"></iron-icon>'

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -194,7 +194,6 @@ class FanXiaomi extends HTMLElement {
             this.card = card;
             this.appendChild(card);
         }
-        const attrs = state.attributes;
 
         // Set and update UI parameters
         this.setUI(this.card.querySelector('.fan-xiaomi-panel'), {

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -23,7 +23,7 @@ class FanXiaomi extends HTMLElement {
 
         const attrs = state.attributes;
 
-        let p5_speed_list = {"Level 1":1,"Level 2":35,"Level 3":70,"Level 4":100}
+        let p5_speed_list = [1, 35, 70, 100]
         let za4_speed_list = {"Level 1":20,"Level 2":40,"Level 3":60,"Level 4":80, "Level 5":100}
         let model = attrs['model']
         let speed_list

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -445,7 +445,7 @@ Natural
             }
         }
         
-        if (direct_speed_int <= speed_list['Level 1']) {
+        if (direct_speed_int <= speed_list[0]) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
         } else if (direct_speed_int <= speed_list['Level 2']) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-2-box-outline"></iron-icon>'

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -24,7 +24,7 @@ class FanXiaomi extends HTMLElement {
         const attrs = state.attributes;
 
         let p5_speed_list = [1, 35, 70, 100]
-        let za4_speed_list = {"Level 1":20,"Level 2":40,"Level 3":60,"Level 4":80, "Level 5":100}
+        let za4_speed_list = [20, 40, 60, 80, 100]
         let model = attrs['model']
         let speed_list
         if (model === 'dmaker.fan.p5') {

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -86,7 +86,7 @@ class FanXiaomi extends HTMLElement {
                     let icon = u.querySelector('.icon-waper > iron-icon')
                     let newSpeed
                     if (icon.getAttribute('icon') == "mdi:numeric-1-box-outline") {
-                        newSpeed = speed_list['Level 2']
+                        newSpeed = speed_list[1]
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-2-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-2-box-outline") {
                         newSpeed = speed_list['Level 3']

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -207,6 +207,7 @@ class FanXiaomi extends HTMLElement {
             delay_off_countdown: attrs['delay_off_countdown'],
             angle: attrs['angle'],
             speed: attrs['speed'],
+            mode: attrs['mode'],
             model: attrs['model'],
             speed_list: speed_list
         })
@@ -377,7 +378,7 @@ Natural
   
     setUI(fanboxa, {title, natural_speed, direct_speed, state,
         child_lock, oscillating, led_brightness, delay_off_countdown, angle, 
-        speed, model, speed_list
+        speed, mode, model, speed_list
     }) {
         fanboxa.querySelector('.var-title').textContent = title
         // Child Lock
@@ -435,8 +436,13 @@ Natural
         }
         let direct_speed_int = Number(direct_speed)
         
-        if (model === 'dmaker.fan.p5') { //p5 does not report direct_speed
+        if (model === 'dmaker.fan.p5') { //p5 does not report direct_speed and natural_speed
             direct_speed_int = speed_list[speed]
+            if (mode === 'nature') {
+                natural_speed = true
+            } else if (mode === 'normal') {
+                natural_speed = false
+            }
         }
         
         if (direct_speed_int <= speed_list['Level 1']) {

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -95,11 +95,11 @@ class FanXiaomi extends HTMLElement {
                         newSpeed = speed_list['Level 4']
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-4-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-4-box-outline") {
-                        if (model === 'dmaker.fan.p5') { // For p5 last speed is Level 4
-                            newSpeed = speed_list['Level 1']
+                        if speed_list[5] === undefined {
+                            newSpeed = speed_list[0]
                             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
                         } else {
-                            newSpeed = speed_list['Level 5']
+                            newSpeed = speed_list[4]
                             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-5-box-outline"></iron-icon>'
                         }
                     } else if (icon.getAttribute('icon') == "mdi:numeric-5-box-outline") {


### PR DESCRIPTION
p5 model does not report current direct_speed at which it's operating, so need to use Levels 1-4 which miio reports back to us.
Because p5 reporting only 4 levels, need to loop from 4th level back to 1st. That's the reason levels are different from za4 as well.
In order to support p5 and za4 simultaneously, added speed_list array.
According to my plan, it should work for za4 as before.