### PR TITLE
Added support for Xiaomi miio airpurifier integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ name: Fan Name
 type: 'custom:fan-xiaomi'
 platform: xiaomi_miio_airpurifier
 ```
-| Card attribute            | Default           | Description                       |
-|---------------------------|-------------------|-----------------------------------|
-| `entity_id`               |      n\a          | Specify Xiaomi miio fan entity_id |
-| `name`                    |      n\a          | Fan name to be show for on card   |
-| `type`                    |`custom:fan-xiaomi`| Mandatory card type specification |
+| Card attribute            | Default           | Description                                         |
+|---------------------------|-------------------|-----------------------------------------------------|
+| `entity_id`               |      n\a          | Specify Xiaomi miio fan entity_id                   |
+| `name`                    |      n\a          | Fan name to be show for on card                     |
+| `type`                    |`custom:fan-xiaomi`| Mandatory card type specification                   |
+| `show_animation`          | `True`            | Flag that defines whether to show fan animation     |
 | `platform`                |`xiaomi_miio_fan`  | For [Xiaomi Mi Air Purifier & Xiaomi Mi Air Humidifier Integration](https://github.com/syssi/xiaomi_airpurifier) you must specify `xiaomi_miio_airpurifier`, if [Xiaomi Mi Smart Pedestal Fan Integration](https://github.com/syssi/xiaomi_fan) is used then can specify `xiaomi_miio_fan` or can ommit it. |
 
 ## Preview

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Xiaomi Smartmi Fan Lovelace card for HASS/Home Assistant.
 - Timer duration
 
 ## Requirements
+Either of these two integrations can be used:
 - [Xiaomi Mi Smart Pedestal Fan Integration](https://github.com/syssi/xiaomi_fan) v0.3.3
+- [Xiaomi Mi Air Purifier & Xiaomi Mi Air Humidifier Integration](https://github.com/syssi/xiaomi_airpurifier) v0.6.9
 
 ## HACS Installation
 Search for `Xiaomi Smartmi Fan Card`
@@ -32,13 +34,18 @@ Search for `Xiaomi Smartmi Fan Card`
     - url: /community_plugin/lovelace-fan-xiaomi/fan-xiaomi.js
       type: js
     ```
-1. Add the following to your Lovelace config `views.cards` key
-    ```yaml
-    entity: fan.entity_id
-    name: Fan Name
-    type: 'custom:fan-xiaomi'
-    ```
-    Replace `fan.entity_id` with your fan's entity_id and `Fan Name` with any name you'd like to name your fan with
+
+## Card Configuration
+
+Add the following to your Lovelace config `views.cards` key
+```yaml
+entity: fan.entity_id
+name: Fan Name
+type: 'custom:fan-xiaomi'
+platform: xiaomi_miio_airpurifier
+```
+1. Replace `fan.entity_id` with your fan's entity_id and `Fan Name` with any name you'd like to name your fan with.
+2. Set `platform` to either `xiaomi_miio_airpurifier` or `xiaomi_miio_fan`(if parameter not specified - `xiaomi_miio_fan` is used). For [Xiaomi Mi Air Purifier & Xiaomi Mi Air Humidifier Integration](https://github.com/syssi/xiaomi_airpurifier) you must specify `xiaomi_miio_airpurifier`, if [Xiaomi Mi Smart Pedestal Fan Integration](https://github.com/syssi/xiaomi_fan) is used then can specify `xiaomi_miio_fan` or can ommit it.
 
 ## Preview
 ![](preview.gif)

--- a/README.md
+++ b/README.md
@@ -37,15 +37,19 @@ Search for `Xiaomi Smartmi Fan Card`
 
 ## Card Configuration
 
-Add the following to your Lovelace config `views.cards` key
+Example of Lovelace config `views.cards` key
 ```yaml
 entity: fan.entity_id
 name: Fan Name
 type: 'custom:fan-xiaomi'
 platform: xiaomi_miio_airpurifier
 ```
-1. Replace `fan.entity_id` with your fan's entity_id and `Fan Name` with any name you'd like to name your fan with.
-2. Set `platform` to either `xiaomi_miio_airpurifier` or `xiaomi_miio_fan`(if parameter not specified - `xiaomi_miio_fan` is used). For [Xiaomi Mi Air Purifier & Xiaomi Mi Air Humidifier Integration](https://github.com/syssi/xiaomi_airpurifier) you must specify `xiaomi_miio_airpurifier`, if [Xiaomi Mi Smart Pedestal Fan Integration](https://github.com/syssi/xiaomi_fan) is used then can specify `xiaomi_miio_fan` or can ommit it.
+| Card attribute            | Default           | Description                       |
+|---------------------------|-------------------|-----------------------------------|
+| `entity_id`               |      n\a          | Specify Xiaomi miio fan entity_id |
+| `name`                    |      n\a          | Fan name to be show for on card   |
+| `type`                    |`custom:fan-xiaomi`| Mandatory card type specification |
+| `platform`                |`xiaomi_miio_fan`  | For [Xiaomi Mi Air Purifier & Xiaomi Mi Air Humidifier Integration](https://github.com/syssi/xiaomi_airpurifier) you must specify `xiaomi_miio_airpurifier`, if [Xiaomi Mi Smart Pedestal Fan Integration](https://github.com/syssi/xiaomi_fan) is used then can specify `xiaomi_miio_fan` or can ommit it. |
 
 ## Preview
 ![](preview.gif)

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ name: Fan Name
 type: 'custom:fan-xiaomi'
 platform: xiaomi_miio_airpurifier
 ```
-| Card attribute            | Default                | Description                                         |
-|---------------------------|------------------------|-----------------------------------------------------|
-| `entity_id`               |      n\a               | Specify Xiaomi miio fan entity_id                   |
-| `name`                    |      n\a               | Fan name to be show for on card                     |
-| `type`                    |`custom:fan-xiaomi`     | Mandatory card type specification                   |
-| `show_animation`          | `True`                 | Flag that defines whether to show fan animation     |
-| `platform`                |`xiaomi_miio_fan`       | For [Xiaomi Mi Air Purifier & Xiaomi Mi Air Humidifier Integration](https://github.com/syssi/xiaomi_airpurifier) you must specify `xiaomi_miio_airpurifier`, if [Xiaomi Mi Smart Pedestal Fan Integration](https://github.com/syssi/xiaomi_fan) is used then can specify `xiaomi_miio_fan` or can ommit it. |
+| Card attribute          | Default                | Description                                     |
+|-------------------------|------------------------|-------------------------------------------------|
+| `entity_id`             |      n\a               | Specify Xiaomi miio fan entity_id               |
+| `name`                  |      n\a               | Fan name to be show for on card                 |
+| `type`                  |`custom:fan-xiaomi`     | Mandatory card type specification               |
+| `show_animation`        | `True`                 | Flag that defines whether to show fan animation |
+| `platform`              |`xiaomi_miio_fan`       | For [Xiaomi Mi Air Purifier & Xiaomi Mi Air Humidifier Integration](https://github.com/syssi/xiaomi_airpurifier) you must specify `xiaomi_miio_airpurifier`, if [Xiaomi Mi Smart Pedestal Fan Integration](https://github.com/syssi/xiaomi_fan) is used then can specify `xiaomi_miio_fan` or can ommit it. |
 
 ## Preview
 ![](preview.gif)

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ name: Fan Name
 type: 'custom:fan-xiaomi'
 platform: xiaomi_miio_airpurifier
 ```
-| Card attribute            | Default           | Description                                         |
-|---------------------------|-------------------|-----------------------------------------------------|
-| `entity_id`               |      n\a          | Specify Xiaomi miio fan entity_id                   |
-| `name`                    |      n\a          | Fan name to be show for on card                     |
-| `type`                    |`custom:fan-xiaomi`| Mandatory card type specification                   |
-| `show_animation`          | `True`            | Flag that defines whether to show fan animation     |
-| `platform`                |`xiaomi_miio_fan`  | For [Xiaomi Mi Air Purifier & Xiaomi Mi Air Humidifier Integration](https://github.com/syssi/xiaomi_airpurifier) you must specify `xiaomi_miio_airpurifier`, if [Xiaomi Mi Smart Pedestal Fan Integration](https://github.com/syssi/xiaomi_fan) is used then can specify `xiaomi_miio_fan` or can ommit it. |
+| Card attribute            | Default                | Description                                         |
+|---------------------------|------------------------|-----------------------------------------------------|
+| `entity_id`               |      n\a               | Specify Xiaomi miio fan entity_id                   |
+| `name`                    |      n\a               | Fan name to be show for on card                     |
+| `type`                    |`custom:fan-xiaomi`     | Mandatory card type specification                   |
+| `show_animation`          | `True`                 | Flag that defines whether to show fan animation     |
+| `platform`                |`xiaomi_miio_fan`       | For [Xiaomi Mi Air Purifier & Xiaomi Mi Air Humidifier Integration](https://github.com/syssi/xiaomi_airpurifier) you must specify `xiaomi_miio_airpurifier`, if [Xiaomi Mi Smart Pedestal Fan Integration](https://github.com/syssi/xiaomi_fan) is used then can specify `xiaomi_miio_fan` or can ommit it. |
 
 ## Preview
 ![](preview.gif)

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -39,6 +39,8 @@ class FanXiaomi extends HTMLElement {
         if (attrs['model'] === 'dmaker.fan.p5'){
             this.supportedAttributes.natural_speed_reporting = false;
         }
+        
+        var platform = this.config.platform || 'xiaomi_miio_fan';
 
 
         if (!this.card) {
@@ -154,7 +156,7 @@ class FanXiaomi extends HTMLElement {
                         b.classList.add('loading')
 
                         this.log(`Set angle to: ${newAngle}`)
-                        hass.callService('xiaomi_miio_fan', 'fan_set_oscillation_angle', {
+                        hass.callService(platform, 'fan_set_oscillation_angle', {
                             entity_id: entityId,
                             angle: newAngle
                         });
@@ -221,13 +223,14 @@ class FanXiaomi extends HTMLElement {
                         b.classList.add('loading')
 
                         this.log(`Set timer to: ${newTimer}`)
-                        hass.callService('xiaomi_miio_fan', 'fan_set_delay_off', {
+                        hass.callService(platform, 'fan_set_delay_off', {
                             entity_id: entityId,
                             delay_off_countdown: newTimer
                         });
                     }
                 }
             }
+            
 
             // Child lock event bindings
             ui.querySelector('.button-childlock').onclick = () => {
@@ -240,11 +243,11 @@ class FanXiaomi extends HTMLElement {
                         let newAngle
                         if (oldChildLockState === 'On') {
                             this.log(`Set child lock to: Off`)
-                            hass.callService('xiaomi_miio_fan', 'fan_set_child_lock_off')
+                            hass.callService(platform, 'fan_set_child_lock_off')
                             u.innerHTML = 'Off'
                         } else if (oldChildLockState === 'Off') {
                             this.log(`Set child lock to: On`)
-                            hass.callService('xiaomi_miio_fan', 'fan_set_child_lock_on')
+                            hass.callService(platform, 'fan_set_child_lock_on')
                             u.innerHTML = 'On'
                         } else {
                             this.error(`Error setting child lock. oldChildLockState = ${oldChildLockState}`)
@@ -264,13 +267,13 @@ class FanXiaomi extends HTMLElement {
                     if (u.classList.contains('active') === false) {
                         this.log(`Set natural mode to: On`)
                         u.classList.add('active')
-                        hass.callService('xiaomi_miio_fan', 'fan_set_natural_mode_on', {
+                        hass.callService(platform, 'fan_set_natural_mode_on', {
                             entity_id: entityId
                         });
                     } else {
                         this.log(`Set natural mode to: Off`)
                         u.classList.remove('active')
-                        hass.callService('xiaomi_miio_fan', 'fan_set_natural_mode_off', {
+                        hass.callService(platform, 'fan_set_natural_mode_off', {
                             entity_id: entityId
                         });
                     }


### PR DESCRIPTION
This implements #44  request. This integration populates more attributes for p5 fan than original xiaomi_miio_fan.
