### PR TITLE
Add default platform for xiaomi_miio HA core integration

### DIFF
--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -46,376 +46,481 @@ class FanXiaomi extends HTMLElement {
     }
 
     set hass(hass) {
-        const entityId = this.config.entity;
-        //const style = this.config.style || '';
-        const myname = this.config.name;
-        const state = hass.states[entityId];
-        const ui = this.getUI();
-        const platform = this.config.platform || 'xiaomi_miio_fan';
-        const use_standard_speeds = this.config.use_standard_speeds || false;
-        const force_sleep_mode_support = this.config.force_sleep_mode_support || false;
-        
+        // Store most recent `hass` instance so we can update in the editor preview.
+        // This should only be used in setConfig()
+        this.mostRecentHass = hass;
 
-        if (!this.card){
-            const card = document.createElement('ha-card');
-            card.className = 'fan-xiaomi'
-            card.appendChild(ui)
-
-            // Check if fan is disconnected
-            if(state === undefined || state.state === 'unavailable'){
-                card.classList.add('offline');
-                this.card = card;
-                this.appendChild(card);
-                ui.querySelector('.var-title').textContent = (this.config.name || '') + ' (Disconnected)';
-                return;
-            }
-        }
-        
-        if (state.state === 'unavailable'){
-            ui.querySelector('.var-title').textContent = (this.config.name || '') + ' (Disconnected)';
-            return;
-        }
-        
-        const attrs = state.attributes;
-
-        if (['dmaker.fan.1c'].includes(attrs['model'])){
-            this.supportedAttributes.angle = false;
-            this.supportedAttributes.childLock = true;
-            this.supportedAttributes.rotationAngle = false;
-            this.supportedAttributes.speedLevels = 3;
-            this.supportedAttributes.natural_speed = true;
-            this.supportedAttributes.natural_speed_reporting = false;
-        }
-        if (['dmaker.fan.p15', 'dmaker.fan.p11', 'dmaker.fan.p10', 'dmaker.fan.p5'].includes(attrs['model'])){
-            this.supportedAttributes.natural_speed_reporting = false;
-            this.supportedAttributes.supported_angles = [30, 60, 90, 120, 140];
-            //this.supportedAttributes.led = true;
-        }
-        if (['dmaker.fan.p9'].includes(attrs['model'])){
-            this.supportedAttributes.natural_speed_reporting = false;
-            this.supportedAttributes.supported_angles = [30, 60, 90, 120, 150];
-        }
-        if (['leshow.fan.ss4'].includes(attrs['model'])){
-            this.supportedAttributes.angle = false;
-            this.supportedAttributes.childLock = false;
-            this.supportedAttributes.rotationAngle = false;
-            this.supportedAttributes.natural_speed = false;
-            this.supportedAttributes.natural_speed_reporting = false;
-            this.supportedAttributes.sleep_mode = true;
-        }
-
-        //trick to support of 'any' fan
-        if (use_standard_speeds) {
-            this.supportedAttributes.speedList = ['low', 'medium', 'high']
-        }
-        if (force_sleep_mode_support) {
-            this.supportedAttributes.sleep_mode = true;
-        }
+        if (this.configuring) return;
 
         if (!this.card) {
-            const card = document.createElement('ha-card');
-            card.className = 'fan-xiaomi'
+            this.configuring = true;
+            this.configureAsync(hass)
+                .then(() => {
+                    this.createCard(hass);
+                    this.updateUI(hass);
+                    this.configuring = false;
+                });
+        } else {
+            this.updateUI(hass);
+        }
+    }
 
-            // Create UI
-            card.appendChild(ui)
+    async configureAsync(hass) {
+        if (this.config.platform === 'default') {
+            const entities = await hass.callWS({ type: "config/entity_registry/list" });
+            const deviceId = entities.find(e => e.entity_id === this.config.entity).device_id;
+            const deviceEntities = entities.filter(e => e.device_id === deviceId);
+    
+            const attributes = hass.states[this.config.entity].attributes;
+ 
+            this.supportedAttributes.speedList = ['low', 'medium', 'high'];
+            if (attributes.speed_list) {
+                this.supportedAttributes.speedList = attributes.speed_list.filter(s => {
+                    const speed = s.toLowerCase();
+                    return speed !== "nature" && speed !== "normal" && speed !== "off";
+                });
+            }
+    
+            if (attributes.preset_mode && attributes.preset_modes && attributes.preset_modes.includes("Nature")) {
+                this.supportedAttributes.natural_speed = true;
+                this.supportedAttributes.natural_speed_reporting = false;
+            }
+    
+            const oscillationEntity = deviceEntities.find(e => e.entity_id.startsWith("number.") && e.entity_id.endsWith("_oscillation_angle"));
+            if (oscillationEntity) {
+                this.oscillation_angle_entity = oscillationEntity.entity_id;
+                this.supportedAttributes.angle = true;
+                const attr = hass.states[this.oscillation_angle_entity].attributes;
+                if (attr.min && attr.max && attr.step) {
+                    const angles = [];
+                    for (let a = attr.min; a <= attr.max; a += attr.step) {
+                        angles.push(a);
+                    }
+                    this.supportedAttributes.supported_angles = angles;
+                }
+            }
+    
+            const delayEntity = deviceEntities.find(e => e.entity_id.startsWith("number.") && e.entity_id.endsWith("_delay_off_countdown"));
+            if (delayEntity) {
+                this.delay_off_entity = delayEntity.entity_id;
+                this.supportedAttributes.timer = true;
+            }
 
-            // Angle adjustment event bindings
-            ui.querySelector('.left').onmouseover = () => {
-                ui.querySelector('.left').classList.replace('hidden','show')
+            const childLockEntity = deviceEntities.find(e => e.entity_id.startsWith("switch.") && e.entity_id.endsWith("_child_lock"));
+            if (childLockEntity) {
+                this.child_lock_entity = childLockEntity.entity_id;
+                this.supportedAttributes.childLock = true;
             }
-            ui.querySelector('.left').onmouseout = () => {
-                ui.querySelector('.left').classList.replace('show','hidden')
+
+            const ledEntity = deviceEntities.find(e => e.entity_id.startsWith("number.") && e.entity_id.endsWith("_led_brightness"));
+            if (ledEntity) {
+                this.led_brightness_entity = ledEntity.entity_id;
+                this.supportedAttributes.led = true;
             }
-            ui.querySelector('.left').onclick = () => {
-                if (ui.querySelector('.fanbox').classList.contains('active')) {
-                    this.log('Rotate left 5 degrees')
-                    hass.callService('fan', 'set_direction', {
+
+            const tempSensorEntity = deviceEntities.find(e => e.entity_id.startsWith("sensor.") && e.entity_id.endsWith("_temperature"));
+            if (tempSensorEntity) {
+                this.temp_sensor_entity = tempSensorEntity.entity_id;
+            }
+
+            const humiditySensorEntity = deviceEntities.find(e => e.entity_id.startsWith("sensor.") && e.entity_id.endsWith("_humidity"));
+            if (humiditySensorEntity) {
+                this.humidity_sensor_entity = humiditySensorEntity.entity_id;
+            }
+
+            const powerSupplyEntity = deviceEntities.find(e => e.entity_id.startsWith("binary_sensor.") && e.entity_id.endsWith("_power_supply"));
+            if (powerSupplyEntity) {
+                this.power_supply_entity = powerSupplyEntity.entity_id;
+            }
+        } else {
+            const entityId = this.config.entity;
+            //const style = this.config.style || '';
+            const state = hass.states[entityId];
+            const attrs = state.attributes;
+
+            if (['dmaker.fan.1c'].includes(attrs['model'])){
+                this.supportedAttributes.angle = false;
+                this.supportedAttributes.childLock = true;
+                this.supportedAttributes.rotationAngle = false;
+                this.supportedAttributes.speedLevels = 3;
+                this.supportedAttributes.natural_speed = true;
+                this.supportedAttributes.natural_speed_reporting = false;
+            }
+            if (['dmaker.fan.p15', 'dmaker.fan.p11', 'dmaker.fan.p10', 'dmaker.fan.p5'].includes(attrs['model'])){
+                this.supportedAttributes.natural_speed_reporting = false;
+                this.supportedAttributes.supported_angles = [30, 60, 90, 120, 140];
+                //this.supportedAttributes.led = true;
+            }
+            if (['dmaker.fan.p9'].includes(attrs['model'])){
+                this.supportedAttributes.natural_speed_reporting = false;
+                this.supportedAttributes.supported_angles = [30, 60, 90, 120, 150];
+            }
+            if (['leshow.fan.ss4'].includes(attrs['model'])){
+                this.supportedAttributes.angle = false;
+                this.supportedAttributes.childLock = false;
+                this.supportedAttributes.rotationAngle = false;
+                this.supportedAttributes.natural_speed = false;
+                this.supportedAttributes.natural_speed_reporting = false;
+                this.supportedAttributes.sleep_mode = true;
+            }
+
+            //trick to support of 'any' fan
+            if (this.config.use_standard_speeds) {
+                this.supportedAttributes.speedList = ['low', 'medium', 'high']
+            }
+            if (this.config.force_sleep_mode_support) {
+                this.supportedAttributes.sleep_mode = true;
+            }
+        }
+    }
+
+    createCard(hass) {
+        const state = hass.states[this.config.entity];
+        const entityId = this.config.entity;
+        const ui = this.getUI();
+        const card = document.createElement('ha-card');
+        card.className = 'fan-xiaomi'
+        card.appendChild(ui)
+
+        // Check if fan is disconnected
+        if (state === undefined || state.state === 'unavailable') {
+            card.classList.add('offline');
+            this.card = card;
+            this.appendChild(card);
+            ui.querySelector('.var-title').textContent = this.config.name + ' (Disconnected)';
+            return;
+        }
+
+        // Angle adjustment event bindings
+        ui.querySelector('.left').onmouseover = () => {
+            ui.querySelector('.left').classList.replace('hidden','show')
+        }
+        ui.querySelector('.left').onmouseout = () => {
+            ui.querySelector('.left').classList.replace('show','hidden')
+        }
+        ui.querySelector('.left').onclick = () => {
+            if (ui.querySelector('.fanbox').classList.contains('active')) {
+                this.log('Rotate left 5 degrees')
+                hass.callService('fan', 'set_direction', {
+                    entity_id: entityId,
+                    direction: this.config.platform === 'default' ? "reverse" : "left"
+                });
+            }
+        }
+        ui.querySelector('.right').onmouseover = () => {
+            ui.querySelector('.right').classList.replace('hidden','show')
+        }
+        ui.querySelector('.right').onmouseout = () => {
+            ui.querySelector('.right').classList.replace('show','hidden')
+        }
+        ui.querySelector('.right').onclick = () => {
+            if (ui.querySelector('.fanbox').classList.contains('active')) {
+                this.log('Rotate right 5 degrees')
+                hass.callService('fan', 'set_direction', {
+                    entity_id: entityId,
+                    direction: this.config.platform === 'default' ? "forward" : "right"
+                });
+            }
+        }
+
+        // Power toggle event bindings
+        ui.querySelector('.c1').onclick = () => {
+            this.log('Toggle')
+            hass.callService('fan', 'toggle', {
+                entity_id: entityId
+            });
+        }
+
+        // Fan speed toggle event bindings
+        ui.querySelector('.var-speed').onclick = () => {
+            this.log('Speed Level')
+            if (ui.querySelector('.fanbox').classList.contains('active')) {
+                //let blades = ui.querySelector('.fanbox .blades')
+                let u = ui.querySelector('.var-speed')
+                //let iconSpan = u.querySelector('.icon-waper')
+                let icon = u.querySelector('.icon-waper > ha-icon').getAttribute('icon')
+                let newSpeedLevel
+                let newSpeed
+
+                let maskSpeedLevel = /mdi:numeric-(\d)-box-outline/g
+                let speedLevelMatch = maskSpeedLevel.exec(icon)
+                let speedLevel = parseInt(speedLevelMatch ? speedLevelMatch[1] : 1)
+                if (this.config.use_standard_speeds || this.config.platform === 'default') {
+                    newSpeedLevel = this.supportedAttributes.speedList[(speedLevel < 
+                        this.supportedAttributes.speedList.length ? speedLevel: 0)]
+                    newSpeed = newSpeedLevel
+                } else {
+                    newSpeedLevel = (speedLevel < this.supportedAttributes.speedLevels ? speedLevel+1: 1)
+                    newSpeed = `Level ${newSpeedLevel}`
+                }
+                
+
+                this.log(`Set speed to: ${newSpeed}`)
+                hass.callService('fan', 'set_speed', {
+                    entity_id: entityId,
+                    speed: newSpeed
+                });
+            }
+        }
+
+        // Fan angle toggle event bindings
+        ui.querySelector('.button-angle').onclick = () => {
+            this.log('Oscillation Angle')
+            if (ui.querySelector('.fanbox').classList.contains('active')) {
+                let b = ui.querySelector('.button-angle')
+                if (!b.classList.contains('loading')) {
+                    let u = ui.querySelector('.var-angle')
+                    let oldAngleText = u.innerHTML
+                    let newAngle
+                    let curAngleIndex = this.supportedAttributes.supported_angles.indexOf(parseInt(oldAngleText,10))
+                    if (curAngleIndex >= 0 && curAngleIndex < this.supportedAttributes.supported_angles.length-1) {
+                        newAngle = this.supportedAttributes.supported_angles[curAngleIndex+1]
+                    } else {
+                        newAngle = this.supportedAttributes.supported_angles[0]
+                    }
+                    b.classList.add('loading')
+
+                    this.log(`Set angle to: ${newAngle}`)
+                    if (this.oscillation_angle_entity) {
+                        hass.callService('number', 'set_value', {
+                            entity_id: this.oscillation_angle_entity,
+                            value: newAngle
+                        })
+                    } else {
+                    hass.callService(this.config.platform, 'fan_set_oscillation_angle', {
                         entity_id: entityId,
-                        direction: "left"
+                        angle: newAngle
+                    });
+                    }
+                }
+            }
+        }
+
+        // Timer toggle event bindings
+        ui.querySelector('.button-timer').onclick = () => {
+            this.log('Timer')
+            if (ui.querySelector('.fanbox').classList.contains('active')) {
+                let b = ui.querySelector('.button-timer')
+                if (!b.classList.contains('loading')) {
+                    let u = ui.querySelector('.var-timer')
+
+                    let currTimer
+                    let hoursRegex = /(\d)h/g
+                    let minsRegex = /(\d{1,2})m/g
+                    let hoursMatch = hoursRegex.exec(u.textContent)
+                    let minsMatch = minsRegex.exec(u.textContent)
+                    let currHours = parseInt(hoursMatch ? hoursMatch[1] : '0')
+                    let currMins = parseInt(minsMatch ? minsMatch[1] : '0')
+                    currTimer = currHours * 60 + currMins
+
+                    let newTimer
+                    if (currTimer < 59) {
+                        newTimer = 60
+                    } else if (currTimer < 119) {
+                        newTimer = 120
+                    } else if (currTimer < 179) {
+                        newTimer = 180
+                    } else if (currTimer < 239) {
+                        newTimer = 240
+                    } else if (currTimer < 299) {
+                        newTimer = 300
+                    } else if (currTimer < 359) {
+                        newTimer = 360
+                    } else if (currTimer < 419) {
+                        newTimer = 420
+                    } else if (currTimer < 479) {
+                        newTimer = 480
+                    } else if (currTimer = 480) {
+                        newTimer = 0
+                    } else {
+                        this.error(`Error setting timer. u.textContent = ${u.textContent}; currTimer = ${currTimer}`)
+                        newTimer = 60
+                        this.error(`Defaulting to ${newTimer}`)
+                    }
+
+                    b.classList.add('loading')
+
+                    this.log(`Set timer to: ${newTimer}`)
+                    if (this.delay_off_entity) {
+                        hass.callService('number', 'set_value', {
+                            entity_id: this.delay_off_entity,
+                            value: newTimer
+                        })
+                    } else {
+                    hass.callService(this.config.platform, 'fan_set_delay_off', {
+                        entity_id: entityId,
+                        delay_off_countdown: newTimer
+                    });
+                    }
+                }
+            }
+        }
+
+        // Child lock event bindings
+        ui.querySelector('.button-childlock').onclick = () => {
+            this.log('Child lock')
+            if (ui.querySelector('.fanbox').classList.contains('active')) {
+                let b = ui.querySelector('.button-childlock')
+                if (!b.classList.contains('loading')) {
+                    let u = ui.querySelector('.var-childlock')
+                    const oldChildLockState = u.innerHTML;
+                    const setChildLockOn = oldChildLockState === 'Off' ? true : false;
+                    if (oldChildLockState !== 'Off' && oldChildLockState !== 'On') {
+                        this.error(`Error setting child lock. oldChildLockState = ${oldChildLockState}`);
+                        u.innerHTML = 'Off';
+                    }
+                    this.log(`Set child lock to: ${setChildLockOn ? 'On' : 'Off'}`);
+
+                    if (this.child_lock_entity) {
+                        hass.callService('switch', setChildLockOn ? 'turn_on' : 'turn_off', {
+                            entity_id: this.child_lock_entity,
+                        })
+                    } else {
+                        hass.callService(this.config.platform, setChildLockOn ? 'fan_set_child_lock_on' : 'fan_set_child_lock_off');
+                    }
+                    b.classList.add('loading')
+                }
+            }
+        }
+
+        // Natural mode event bindings
+        ui.querySelector('.var-natural').onclick = () => {
+            this.log('Natural')
+            if (ui.querySelector('.fanbox').classList.contains('active')) {
+                let u = ui.querySelector('.var-natural')
+                let isActive = u.classList.contains('active') !== false;
+                if (this.config.platform === 'default') {
+                    hass.callService('fan', 'set_preset_mode', {
+                        entity_id: entityId,
+                        preset_mode: isActive ? 'Normal' : 'Nature'
+                    })
+                } else if (!isActive) {
+                    this.log(`Set natural mode to: On`)
+                    hass.callService(this.config.platform, 'fan_set_natural_mode_on', {
+                        entity_id: entityId
+                    });
+                } else {
+                    this.log(`Set natural mode to: Off`)
+                    hass.callService(this.config.platform, 'fan_set_natural_mode_off', {
+                        entity_id: entityId
                     });
                 }
             }
-            ui.querySelector('.right').onmouseover = () => {
-                ui.querySelector('.right').classList.replace('hidden','show')
-            }
-            ui.querySelector('.right').onmouseout = () => {
-                ui.querySelector('.right').classList.replace('show','hidden')
-            }
-            ui.querySelector('.right').onclick = () => {
-                if (ui.querySelector('.fanbox').classList.contains('active')) {
-                    this.log('Rotate right 5 degrees')
-                    hass.callService('fan', 'set_direction', {
+        }
+
+        // Sleep mode event bindings
+        ui.querySelector('.var-sleep').onclick = () => {
+            this.log('Sleep')
+            if (ui.querySelector('.fanbox').classList.contains('active')) {
+                let u = ui.querySelector('.var-sleep')
+                if (u.classList.contains('active') === false) {
+                    this.log(`Set sleep mode to: On`)
+                    hass.callService('fan', 'set_percentage', {
                         entity_id: entityId,
-                        direction: "right"
+                        percentage: 1
+                    });
+                } else {
+                    this.log(`Set sleep mode to: Off`)
+                    hass.callService('fan', 'set_speed', {
+                        entity_id: entityId,
+                        speed: 'low'
                     });
                 }
             }
+        }
 
-            // Power toggle event bindings
-            ui.querySelector('.c1').onclick = () => {
+        // LED mode event bindings
+        ui.querySelector('.var-led').onclick = () => {
+            this.log('Led')
+            if (ui.querySelector('.fanbox').classList.contains('active')) {
+                let u = ui.querySelector('.var-led')
+                const setLedOn = !u.classList.contains('active');
+                this.log(`Set led mode to: ${setLedOn ? 'On' : 'Off'}`);
+                if (this.led_brightness_entity) {
+                    hass.callService('number', 'set_value', {
+                        entity_id: this.led_brightness_entity,
+                        value: setLedOn ? 100 : 0
+                    })
+                } else {
+                    hass.callService(this.config.platform, setLedOn ? 'fan_set_led_on' : 'fan_set_led_off', {
+                        entity_id: entityId
+                    });
+                }
+            }
+        }
+
+        // Oscillation toggle event bindings
+        ui.querySelector('.var-oscillating').onclick = () => {
+            this.log('Oscillate')
+            if (ui.querySelector('.fanbox').classList.contains('active')) {
+                let u = ui.querySelector('.var-oscillating')
+                if (u.classList.contains('active') === false) {
+                    this.log(`Set oscillation to: On`)
+                    hass.callService('fan', 'oscillate', {
+                        entity_id: entityId,
+                        oscillating: true
+                    });
+                } else {
+                    this.log(`Set oscillation to: Off`)
+                    hass.callService('fan', 'oscillate', {
+                        entity_id: entityId,
+                        oscillating: false
+                    });
+                }
+            }
+        }
+        
+        //Fan title works as on/off button when animation is disabled
+        if (this.config.disable_animation) {
+            ui.querySelector('.var-title').onclick = () => {
                 this.log('Toggle')
                 hass.callService('fan', 'toggle', {
                     entity_id: entityId
                 });
             }
-
-            // Fan speed toggle event bindings
-            ui.querySelector('.var-speed').onclick = () => {
-                this.log('Speed Level')
-                if (ui.querySelector('.fanbox').classList.contains('active')) {
-                    //let blades = ui.querySelector('.fanbox .blades')
-                    let u = ui.querySelector('.var-speed')
-                    //let iconSpan = u.querySelector('.icon-waper')
-                    let icon = u.querySelector('.icon-waper > ha-icon').getAttribute('icon')
-                    let newSpeedLevel
-                    let newSpeed
-
-                    let maskSpeedLevel = /mdi:numeric-(\d)-box-outline/g
-                    let speedLevelMatch = maskSpeedLevel.exec(icon)
-                    let speedLevel = parseInt(speedLevelMatch ? speedLevelMatch[1] : 1)
-                    if (use_standard_speeds) {
-                        newSpeedLevel = this.supportedAttributes.speedList[(speedLevel < 
-                            this.supportedAttributes.speedList.length ? speedLevel: 0)]
-                        newSpeed = newSpeedLevel
-                    } else {
-                        newSpeedLevel = (speedLevel < this.supportedAttributes.speedLevels ? speedLevel+1: 1)
-                        newSpeed = `Level ${newSpeedLevel}`
-                    }
-                    
-
-                    this.log(`Set speed to: ${newSpeed}`)
-                    hass.callService('fan', 'set_speed', {
-                        entity_id: entityId,
-                        speed: newSpeed
-                    });
-                }
-            }
-
-            // Fan angle toggle event bindings
-            ui.querySelector('.button-angle').onclick = () => {
-                this.log('Oscillation Angle')
-                if (ui.querySelector('.fanbox').classList.contains('active')) {
-                    let b = ui.querySelector('.button-angle')
-                    if (!b.classList.contains('loading')) {
-                        let u = ui.querySelector('.var-angle')
-                        let oldAngleText = u.innerHTML
-                        let newAngle
-                        let curAngleIndex = this.supportedAttributes.supported_angles.indexOf(parseInt(oldAngleText,10))
-                        if (curAngleIndex >= 0 && curAngleIndex < this.supportedAttributes.supported_angles.length-1) {
-                            newAngle = this.supportedAttributes.supported_angles[curAngleIndex+1]
-                        } else {
-                            newAngle = this.supportedAttributes.supported_angles[0]
-                        }
-                        b.classList.add('loading')
-
-                        this.log(`Set angle to: ${newAngle}`)
-                        hass.callService(platform, 'fan_set_oscillation_angle', {
-                            entity_id: entityId,
-                            angle: newAngle
-                        });
-                    }
-                }
-            }
-
-            // Timer toggle event bindings
-            ui.querySelector('.button-timer').onclick = () => {
-                this.log('Timer')
-                if (ui.querySelector('.fanbox').classList.contains('active')) {
-                    let b = ui.querySelector('.button-timer')
-                    if (!b.classList.contains('loading')) {
-                        let u = ui.querySelector('.var-timer')
-
-                        let currTimer
-                        let hoursRegex = /(\d)h/g
-                        let minsRegex = /(\d{1,2})m/g
-                        let hoursMatch = hoursRegex.exec(u.textContent)
-                        let minsMatch = minsRegex.exec(u.textContent)
-                        let currHours = parseInt(hoursMatch ? hoursMatch[1] : '0')
-                        let currMins = parseInt(minsMatch ? minsMatch[1] : '0')
-                        currTimer = currHours * 60 + currMins
-
-                        let newTimer
-                        if (currTimer < 59) {
-                            newTimer = 60
-                        } else if (currTimer < 119) {
-                            newTimer = 120
-                        } else if (currTimer < 179) {
-                            newTimer = 180
-                        } else if (currTimer < 239) {
-                            newTimer = 240
-                        } else if (currTimer < 299) {
-                            newTimer = 300
-                        } else if (currTimer < 359) {
-                            newTimer = 360
-                        } else if (currTimer < 419) {
-                            newTimer = 420
-                        } else if (currTimer < 479) {
-                            newTimer = 480
-                        } else if (currTimer = 480) {
-                            newTimer = 0
-                        } else {
-                            this.error(`Error setting timer. u.textContent = ${u.textContent}; currTimer = ${currTimer}`)
-                            newTimer = 60
-                            this.error(`Defaulting to ${newTimer}`)
-                        }
-
-                        b.classList.add('loading')
-
-                        this.log(`Set timer to: ${newTimer}`)
-                        hass.callService(platform, 'fan_set_delay_off', {
-                            entity_id: entityId,
-                            delay_off_countdown: newTimer
-                        });
-                    }
-                }
-            }
-            
-
-            // Child lock event bindings
-            ui.querySelector('.button-childlock').onclick = () => {
-                this.log('Child lock')
-                if (ui.querySelector('.fanbox').classList.contains('active')) {
-                    let b = ui.querySelector('.button-childlock')
-                    if (!b.classList.contains('loading')) {
-                        let u = ui.querySelector('.var-childlock')
-                        let oldChildLockState = u.innerHTML
-                        if (oldChildLockState === 'On') {
-                            this.log(`Set child lock to: Off`)
-                            hass.callService(platform, 'fan_set_child_lock_off')
-                        } else if (oldChildLockState === 'Off') {
-                            this.log(`Set child lock to: On`)
-                            hass.callService(platform, 'fan_set_child_lock_on')
-                        } else {
-                            this.error(`Error setting child lock. oldChildLockState = ${oldChildLockState}`)
-                            this.error(`Defaulting to Off`)
-                            hass.callService(platform, 'fan_set_child_lock_off')
-                            u.innerHTML = 'Off'
-                        }
-                        b.classList.add('loading')
-                    }
-                }
-            }
-
-            // Natural mode event bindings
-            ui.querySelector('.var-natural').onclick = () => {
-                this.log('Natural')
-                if (ui.querySelector('.fanbox').classList.contains('active')) {
-                    let u = ui.querySelector('.var-natural')
-                    if (u.classList.contains('active') === false) {
-                        this.log(`Set natural mode to: On`)
-                        hass.callService(platform, 'fan_set_natural_mode_on', {
-                            entity_id: entityId
-                        });
-                    } else {
-                        this.log(`Set natural mode to: Off`)
-                        hass.callService(platform, 'fan_set_natural_mode_off', {
-                            entity_id: entityId
-                        });
-                    }
-                }
-            }
-
-            // Sleep mode event bindings
-            ui.querySelector('.var-sleep').onclick = () => {
-                this.log('Sleep')
-                if (ui.querySelector('.fanbox').classList.contains('active')) {
-                    let u = ui.querySelector('.var-sleep')
-                    if (u.classList.contains('active') === false) {
-                        this.log(`Set sleep mode to: On`)
-                        hass.callService('fan', 'set_percentage', {
-                            entity_id: entityId,
-                            percentage: 1
-                        });
-                    } else {
-                        this.log(`Set sleep mode to: Off`)
-                        hass.callService('fan', 'set_speed', {
-                            entity_id: entityId,
-                            speed: 'low'
-                        });
-                    }
-                }
-            }
-
-            // LED mode event bindings
-            ui.querySelector('.var-led').onclick = () => {
-                this.log('Led')
-                if (ui.querySelector('.fanbox').classList.contains('active')) {
-                    let u = ui.querySelector('.var-led')
-                    if (u.classList.contains('active') === false) {
-                        this.log(`Set led mode to: On`)
-                        hass.callService(platform, 'fan_set_led_on', {
-                            entity_id: entityId
-                        });
-                    } else {
-                        this.log(`Set led mode to: Off`)
-                        hass.callService(platform, 'fan_set_led_off', {
-                            entity_id: entityId
-                        });
-                    }
-                }
-            }
-
-            // Oscillation toggle event bindings
-            ui.querySelector('.var-oscillating').onclick = () => {
-                this.log('Oscillate')
-                if (ui.querySelector('.fanbox').classList.contains('active')) {
-                    let u = ui.querySelector('.var-oscillating')
-                    if (u.classList.contains('active') === false) {
-                        this.log(`Set oscillation to: On`)
-                        hass.callService('fan', 'oscillate', {
-                            entity_id: entityId,
-                            oscillating: true
-                        });
-                    } else {
-                        this.log(`Set oscillation to: Off`)
-                        hass.callService('fan', 'oscillate', {
-                            entity_id: entityId,
-                            oscillating: false
-                        });
-                    }
-                }
-            }
-            
-            //Fan title works as on/off button when animation is disabled
-            if (this.config.disable_animation) {
-                ui.querySelector('.var-title').onclick = () => {
-                    this.log('Toggle')
-                    hass.callService('fan', 'toggle', {
-                        entity_id: entityId
-                    });
-                }
-            } else {
-                ui.querySelector('.var-title').onclick = () => {
-                    this.log('Dialog box')
-                    moreInfo(entityId);
-                }
-            }
-            /*
+        } else {
             ui.querySelector('.var-title').onclick = () => {
                 this.log('Dialog box')
-                card.querySelector('.dialog').style.display = 'block'
-            }*/
-            this.card = card;
-            this.appendChild(card);
+                moreInfo(entityId);
+            }
+        }
+        /*
+        ui.querySelector('.var-title').onclick = () => {
+            this.log('Dialog box')
+            card.querySelector('.dialog').style.display = 'block'
+        }*/
+        this.card = card;
+        this.innerHTML = '';
+        this.appendChild(card);
+    }
+
+    updateUI(hass) {
+        const state = hass.states[this.config.entity];
+
+        if (state.state === 'unavailable') {
+            this.card.querySelector('.var-title').textContent = this.config.name + ' (Disconnected)';
+            return;
         }
 
-        // Set and update UI parameters
+        const attrs = state.attributes;
         this.setUI(this.card.querySelector('.fan-xiaomi-panel'), {
-            title: myname || attrs['friendly_name'],
+            title: this.config.name || attrs['friendly_name'],
             natural_speed: attrs['natural_speed'],
-            direct_speed: attrs['direct_speed'],
-            raw_speed: attrs['raw_speed'],
+            raw_speed: this.config.platform === 'default' ? attrs['percentage'] : attrs['raw_speed'],
             state: state.state,
-            child_lock: attrs['child_lock'],
+            child_lock: this.child_lock_entity ? hass.states[this.child_lock_entity].state === 'on' : attrs['child_lock'],
             oscillating: attrs['oscillating'],
-            led_brightness: attrs['led_brightness'],
-            delay_off_countdown: attrs['delay_off_countdown'],
-            angle: attrs['angle'],
+            led_brightness: this.led_brightness_entity ? hass.states[this.led_brightness_entity].state : attrs['led_brightness'],
+            delay_off_countdown: this.delay_off_entity ? hass.states[this.delay_off_entity].state : attrs['delay_off_countdown'],
+            angle: this.oscillation_angle_entity ? Number(hass.states[this.oscillation_angle_entity].state) : attrs['angle'],
             speed: attrs['speed'],
-            mode: attrs['mode'],
+            mode: this.config.platform === 'default' ? attrs['preset_mode'].toLowerCase() : attrs['mode'],
             model: attrs['model'],
-            led: attrs['led']
-        })
+            led: this.led_brightness_entity ? hass.states[this.led_brightness_entity].state > 0 : attrs['led'],
+            temperature: this.temp_sensor_entity ? hass.states[this.temp_sensor_entity].state : undefined,
+            humidity: this.humidity_sensor_entity ? hass.states[this.humidity_sensor_entity].state : undefined,
+            power_supply: this.power_supply_entity ? hass.states[this.power_supply_entity].state === 'on' : undefined,
+        });
     }
 
     setConfig(config) {
@@ -423,6 +528,12 @@ class FanXiaomi extends HTMLElement {
             throw new Error('You must specify an entity');
         }
         this.config = config;
+
+        // Force re-layout to update the preview
+        if (this.mostRecentHass) {
+            this.card = null;
+            this.hass = this.mostRecentHass;
+        }
     }
 
     // The height of your card. Home Assistant uses this to automatically
@@ -471,6 +582,9 @@ p{margin:0;padding:0}
 .op-row .op .icon-waper{display:block;margin:0 auto 5px;width:30px;height:30px}
 .op-row .op.active button{color:#01be9e!important;text-shadow:0 0 10px #01be9e}
 `+csss+`
+.fanbox-container{position:relative;}
+.var-sensors{position:absolute;left:10px;text-align:left;color:var(--secondary-text-color);}
+.var-power-supply{position:absolute;right:10px;color:var(--secondary-text-color);}
 .fanbox{position:relative;margin:10px auto;width:150px;height:150px;border-radius:50%;background:#80808061}
 .fanbox.active.oscillation{animation:oscillate 8s infinite linear}
 .blades div{position:absolute;margin:15% 0 0 15%;width:35%;height:35%;border-radius:100% 50% 0;background:#989898;transform-origin:100% 100%}
@@ -485,7 +599,7 @@ p{margin:0;padding:0}
 .c1{top:20%;left:20%;width:60%;height:60%;border:2px solid #fff;border-radius:50%;cursor:pointer;baskground:#ffffff00}
 .c1,.c2{position:absolute;box-sizing:border-box}
 .c2{top:0;left:0;width:100%;height:100%;border:10px solid #f7f7f7;border-radius:50%}
-.c3{position:absolute;top:40%;left:40%;box-sizing:border-box;width:20%;height:20%;border-radius:50%;background:#fff;color:#ddd}
+.c3{position:absolute;top:40%;left:40%;box-sizing:border-box;width:20%;height:20%;border-radius:50%;background:#fff;color:#ddd;border:2px solid white;line-height:24px}
 .c3.active{border:2px solid #8dd5c3}
 .c3 span ha-icon{width:100%;height:100%}
 .chevron{position:absolute;top:0;height:100%;opacity:0}
@@ -513,6 +627,9 @@ to{transform:perspective(10em) rotateY(40deg)}
 <div class="title">
 <p class="var-title">Playground</p>
 </div>
+<div class="fanbox-container">
+<div class="var-sensors"></div>
+<div class="var-power-supply"></div>
 <div class="fanbox">
 <div class="blades">
 <div class="b1 ang1"></div>
@@ -536,6 +653,7 @@ to{transform:perspective(10em) rotateY(40deg)}
 <ha-icon icon="mdi:chevron-right"></ha-icon>
 </div>
 </span>
+</div>
 </div>
 </div>
 <div class="attr-row upper-container">
@@ -600,9 +718,9 @@ LED
 
     // Define UI Parameters
 
-    setUI(fanboxa, {title, natural_speed, direct_speed, raw_speed, state,
+    setUI(fanboxa, {title, natural_speed, raw_speed, state,
         child_lock, oscillating, led_brightness, delay_off_countdown, angle,
-        speed, mode, model, led
+        speed, mode, model, led, temperature, humidity, power_supply
     }) {
         fanboxa.querySelector('.var-title').textContent = title
 
@@ -668,7 +786,7 @@ LED
 
         // LED
         let activeElement = fanboxa.querySelector('.c3')
-        if (led_brightness < 2) {
+        if (led_brightness > 0) {
             if (activeElement.classList.contains('active') === false) {
                 activeElement.classList.add('active')
             }
@@ -676,7 +794,7 @@ LED
             activeElement.classList.remove('active')
         }
         activeElement = fanboxa.querySelector('.var-led')
-        if (this.supportedAttributes.led) {
+        if (this.supportedAttributes.led && !this.config.hide_led_button) {
             if (led) {
                 if (activeElement.classList.contains('active') === false) {
                     activeElement.classList.add('active')
@@ -713,7 +831,10 @@ LED
         let speedRegexpMatch
         let speedLevel
         let raw_speed_int = Number(raw_speed)
-        if (!this.config.use_standard_speeds) {
+        if (this.config.use_standard_speeds || this.config.platform === 'default') {
+            let speedCount = this.supportedAttributes.speedList.length
+            speedLevel = Math.round(raw_speed_int/100*speedCount)
+        } else {
             let speedRegexp = /Level (\d)/g
             speedRegexpMatch = speedRegexp.exec(speed)
             if (speedRegexpMatch && speedRegexpMatch.length > 0) {
@@ -722,9 +843,6 @@ LED
             if (speedLevel === undefined) {
                 speedLevel = 1
             }
-        } else {
-            let speedCount = this.supportedAttributes.speedList.length
-            speedLevel = Math.round(raw_speed_int/100*speedCount)
         }
         iconSpan.innerHTML = `<ha-icon icon="mdi:numeric-${speedLevel}-box-outline"></ha-icon>`
         activeElement = fanboxa.querySelector('.fanbox .blades')
@@ -732,20 +850,19 @@ LED
 
         // Natural mode
         activeElement = fanboxa.querySelector('.var-natural')
-        
-         //p* fans do not report direct_speed and natural_speed
-        if (!this.supportedAttributes.natural_speed_reporting && this.supportedAttributes.natural_speed) {
-            if (mode === 'nature') {
-                natural_speed = true
-            } else if (mode === 'normal') {
-                natural_speed = false
-            } else {
-                this.error(`Unrecognized mode for ${model} when updating natural mode state: ${mode}`)
-                natural_speed = false
-                this.error(`Defaulting to natural_speed = ${natural_speed}`)
-            }
-        }
         if (this.supportedAttributes.natural_speed) {
+            //p* fans do not report direct_speed and natural_speed
+            if (!this.supportedAttributes.natural_speed_reporting) {
+                if (mode === 'nature') {
+                    natural_speed = true
+                } else if (mode === 'normal') {
+                    natural_speed = false
+                } else {
+                    this.error(`Unrecognized mode for ${model} when updating natural mode state: ${mode}`)
+                    natural_speed = false
+                    this.error(`Defaulting to natural_speed = ${natural_speed}`)
+                }
+            }
             if (natural_speed) {
                 if (activeElement.classList.contains('active') === false) {
                     activeElement.classList.add('active')
@@ -753,8 +870,7 @@ LED
             } else {
                 activeElement.classList.remove('active')
             }
-        } else
-        {
+        } else {
             activeElement.style.display='none'
         }
 
@@ -768,8 +884,7 @@ LED
             } else {
                 activeElement.classList.remove('active')
             }
-        } else
-        {
+        } else {
             activeElement.style.display='none'
         }
 
@@ -796,10 +911,26 @@ LED
 
         // Fan Animation
         if (this.config.disable_animation) {
-            fanboxa.querySelector('.fanbox').style.display = 'none'
+            fanboxa.querySelector('.fanbox-container').style.display = 'none'
             this.card.style.height = '170px'
-        }
+        } else {
+            // Sensors
+            let sensorContent = "";
+            if (temperature !== undefined) {
+                sensorContent += `${temperature} °C<br />`;
+            }
+            if (humidity !== undefined) {
+                sensorContent += `${humidity} %<br />`;
+            }
+            if (sensorContent) {
+                fanboxa.querySelector('.var-sensors').innerHTML = sensorContent;
+            }
 
+            // Power Supply Icon
+            if (power_supply !== undefined) {
+                fanboxa.querySelector('.var-power-supply').innerHTML = `<ha-icon icon="mdi:power-plug-${power_supply ? '' : 'off-'}outline"></ha-icon>`;
+            }
+        }
     }
 /*********************************** UI Settings ************************************/
 
@@ -818,6 +949,7 @@ LED
 customElements.define('fan-xiaomi', FanXiaomi);
 
 const OptionsPlatform = [
+  'default',
   'xiaomi_miio_fan',
   'xiaomi_miio_airpurifier',
 ];
@@ -825,7 +957,18 @@ const OptionsPlatform = [
 class ContentCardEditor extends LitElement {
 
   setConfig(config) {
-    this.config = config;
+    this.config = {
+        name: "",
+        platform: OptionsPlatform[0],
+        use_standard_speeds: false,
+        force_sleep_mode_support: false,
+        hide_led_button: false,
+        ...config,
+    };
+
+    if (this.config.platform === 'default') {
+        this.config.use_standard_speeds = true;
+    }
   }
 
   static get properties() {
@@ -836,6 +979,9 @@ class ContentCardEditor extends LitElement {
   }
   render() {
     return html`
+    <style>
+        .row{padding-bottom:4px;}
+    </style>
     <div class="card-config">
     <div class="row">
     <paper-input
@@ -844,33 +990,6 @@ class ContentCardEditor extends LitElement {
           .configValue="${"name"}"
           @value-changed="${this._valueChanged}"
       ></paper-input>
-      </div>
-      <div class="row">
-      <ha-formfield label="Disable animation">
-        <ha-switch
-          .checked=${this.config.disable_animation}
-          .configValue="${'disable_animation'}"
-          @change=${this._valueChanged}
-        ></ha-switch>
-      </ha-formfield>
-      </div>
-      <div class="row">
-      <ha-formfield label="Use HA standard speeds (low/medium/high)">
-        <ha-switch
-          .checked=${this.config.use_standard_speeds}
-          .configValue="${'use_standard_speeds'}"
-          @change=${this._valueChanged}
-        ></ha-switch>
-      </ha-formfield>
-      </div>
-      <div class="row">
-      <ha-formfield label="Show sleep mode button">
-        <ha-switch
-          .checked=${this.config.force_sleep_mode_support}
-          .configValue="${'force_sleep_mode_support'}"
-          @change=${this._valueChanged}
-        ></ha-switch>
-      </ha-formfield>
       </div>
       <div class="row">
       <paper-dropdown-menu
@@ -901,6 +1020,43 @@ class ContentCardEditor extends LitElement {
         @change=${this._valueChanged}
         allow-custom-entity
       ></ha-entity-picker>
+      </div>
+      <div class="row">
+      <ha-formfield label="Disable animation">
+        <ha-switch
+          .checked=${this.config.disable_animation}
+          .configValue="${'disable_animation'}"
+          @change=${this._valueChanged}
+        ></ha-switch>
+      </ha-formfield>
+      </div>
+      <div class="row">
+      <ha-formfield label="Use HA standard speeds (low/medium/high)">
+        <ha-switch
+          .disabled=${this.config.platform === 'default'}
+          .checked=${this.config.use_standard_speeds}
+          .configValue="${'use_standard_speeds'}"
+          @change=${this._valueChanged}
+        ></ha-switch>
+      </ha-formfield>
+      </div>
+      <div class="row">
+      <ha-formfield label="Show sleep mode button">
+        <ha-switch
+          .checked=${this.config.force_sleep_mode_support}
+          .configValue="${'force_sleep_mode_support'}"
+          @change=${this._valueChanged}
+        ></ha-switch>
+      </ha-formfield>
+      </div>
+      <div class="row">
+      <ha-formfield label="Hide LED button (for supported devices)">
+        <ha-switch
+          .checked=${this.config.hide_led_button}
+          .configValue="${'hide_led_button'}"
+          @change=${this._valueChanged}
+        ></ha-switch>
+      </ha-formfield>
       </div>
     </div>
     `

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -555,7 +555,7 @@ class FanXiaomi extends HTMLElement {
             state: state.state,
             child_lock: this.child_lock_entity ? hass.states[this.child_lock_entity].state === 'on' : attrs['child_lock'],
             oscillating: attrs['oscillating'],
-            led_brightness: this.led_brightness_entity ? hass.states[this.led_brightness_entity].state : attrs['led_brightness'],
+            led_on: this.led_brightness_entity ? hass.states[this.led_brightness_entity].state > 0 : attrs['led_brightness'] < 2,
             delay_off_countdown: this.delay_off_entity ? hass.states[this.delay_off_entity].state : attrs['delay_off_countdown'],
             angle: this.oscillation_angle_entity ? Number(hass.states[this.oscillation_angle_entity].state) : attrs['angle'],
             speed: attrs['speed'],
@@ -781,7 +781,7 @@ LED
     // Define UI Parameters
 
     setUI(fanboxa, {title, natural_speed, raw_speed, state,
-        child_lock, oscillating, led_brightness, delay_off_countdown, angle,
+        child_lock, oscillating, led_on, delay_off_countdown, angle,
         speed, mode, model, led, temperature, humidity, power_supply
     }) {
         fanboxa.querySelector('.var-title').textContent = title
@@ -848,7 +848,7 @@ LED
 
         // LED
         let activeElement = fanboxa.querySelector('.c3')
-        if (led_brightness > 0) {
+        if (led_on) {
             if (activeElement.classList.contains('active') === false) {
                 activeElement.classList.add('active')
             }


### PR DESCRIPTION
Home Assistant's core Xiaomi Miio integration now creates related entities for sensors and controls which aren't part of the default "fan" service. With this, it's possible to fully control a Xiaomi fan without the `xiaomi_miio_fan` service.

This PR adds a new `default` platform config which uses the built in `fan` service and related entities. Finding the related entities requires an async call, so there's a decent amount of refactoring to make sure we're configured before rendering fully.

I've also added support for a few newer attributes.

Full list of changes:
- Split up the `set hass` getter into config/create/update functions, and ensure we aren't re-creating the entire card unnecessarily one very state change
- Add a new way of configuring when `this.config.platform === 'default'` which checks for features by looking for the relevant entities (no need to hard-code model versions anymore)
- Update click handlers to use related entities if they exist
- Added new UI for temperature and himidity sensors, and power/charging status, for devices which support this (e.g. Fan 3)
- Added a new confing option to hide the LED button as I don't find this useful
- Minor fixes to the power icon positioning to re-center it when LED is off

The diff for this is pretty huge, sorry about that. I can try to split it up if you'd prefer.

Related issues: #64 #61

<img height="350" alt="image" src="https://user-images.githubusercontent.com/2031632/155868846-bacf1f55-d7c1-4488-b7b0-5100d6f6b70d.png"><img height="350" alt="image" src="https://user-images.githubusercontent.com/2031632/155868856-5e4b74a1-6adc-4460-aec3-1191975fdf35.png">
