### PR TITLE
Buttons for Buzzer and Ionizer, Levels for LED brightness

### DIFF
--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -1049,7 +1049,7 @@ Sleep
 <button>
 <span class="icon-waper">
 <ha-icon icon="mdi:lightbulb-outline"></ha-icon>
-<div class="icon-value var-led-brightness">100%</div>
+<div class="icon-value var-led-brightness" style="display:none">100%</div>
 </span>
 LED
 </button>


### PR DESCRIPTION
Added support for buzzer and ionizer.
There will now be additional buttons to toggle the buzzer and ionizer on and off on supported devices.
The LED Button will toggle between 0%, 25%, 75% and 100% brightness if the brightness control value is a number.

![image](https://user-images.githubusercontent.com/6571889/169847686-8dffbbb4-3f57-4dd7-be60-15c281a3fce0.png)

