### PR TITLE
Speed levels rotation + 140 angle in dmaker.fan.p18

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,11 +11,12 @@ import { ignoreSelectFiles } from './elements/ignore/select';
 import { ignoreSwitchFiles } from './elements/ignore/switch';
 
 const dev = process.env.ROLLUP_WATCH;
+const port = process.env.PORT || 5000;
 
 const serveopts = {
   contentBase: ['./dist'],
   host: '0.0.0.0',
-  port: 5000,
+  port,
   allowCrossOrigin: true,
   headers: {
     'Access-Control-Allow-Origin': '*',

--- a/src/xiaomi-fan-card.ts
+++ b/src/xiaomi-fan-card.ts
@@ -209,7 +209,6 @@ export class FanXiaomiCard extends LitElement {
 
   private getTimer(): number {
     if (this.deviceEntities.timer) {
-      console.log();
       let minutesRemaining = Number(this.hass.states[this.deviceEntities.timer].state);
       const max = this.hass.states[this.deviceEntities.timer].attributes["max"];
       if (max && minutesRemaining > max) {
@@ -592,10 +591,10 @@ export class FanXiaomiCard extends LitElement {
                   Speed down
                 </button>
               </div>`
-          : html`<div class="op var-speed ${speedLevel > 0 ? "active" : ""}" @click=${this.toggleSpeedLevel}>
+          : html`<div class="op var-speed ${(speedLevel > 0 && state.state === "on") ? "active" : ""}" @click=${this.toggleSpeedLevel}>
                 <button>
                   <span class="icon-waper">
-                    <ha-icon icon="mdi:numeric-${speedLevel}-box-outline"></ha-icon>
+                    <ha-icon icon="mdi:numeric-${(state.state === "on") ? speedLevel : 0}-box-outline"></ha-icon>
                   </span>
                   Speed
                 </button>
@@ -676,11 +675,15 @@ export class FanXiaomiCard extends LitElement {
    * e.g. if at level 1, jumps to level 2
    * If at the maximum speed, this turns the fan of (i.e. "level 0") as this is the only way to turn off
    *   the fan when animations/fanbox is disabled.
+   *
+   * When animations/fanbox is enabled, max level jumps to level 1.
+   * Jump from level 0 - turns on the fan
    */
   private toggleSpeedLevel(): void {
     const currentLevel = this.getSpeedLevel();
 
-    const newLevel = currentLevel >= this.supportedAttributes.speedLevels ? 0 : currentLevel + 1;
+    const newLevel = currentLevel >= this.supportedAttributes.speedLevels ?
+      (this.config.disable_animation ? (this.hass.states[this.config.entity].state === 'off' ? 1 : 0) : 1) : currentLevel + 1;
     const newPercentage = (newLevel / this.supportedAttributes.speedLevels) * 100;
 
     this.hass.callService("fan", "set_percentage", {

--- a/src/xiaomi-fan-card.ts
+++ b/src/xiaomi-fan-card.ts
@@ -423,7 +423,7 @@ export class FanXiaomiCard extends LitElement {
       const state = this.hass.states[this.config.entity];
       const attrs = state.attributes;
 
-      if (["dmaker.fan.p15"].includes(attrs["model"])) {
+      if (["dmaker.fan.p15", "dmaker.fan.p18"].includes(attrs["model"])) {
         this.supportedAttributes.supportedAngles = [30, 60, 90, 120, 140];
         //this.supportedAttributes.led = true;
       }


### PR DESCRIPTION
This pull request makes the following changes:

### 1. An angle of 140 degrees has been introduced for the dmaker.fan.p18 model
Duplicate of #100
![image](https://user-images.githubusercontent.com/2917861/180335146-3bfb8544-910e-45e8-88bd-5779f30d2524.png)

### 2. When using rollup, you can set the port via the environment variable

### 3. Support for infinite changing speed levels.
With animations disabled:
`turn off (0) -> turn on (1) -> (2) -> (3) -> (4) -> turn off (0) ->  turn on (1) ...`
With animations enabled:
`(1) -> (2) -> (3) -> (4) -> (1) ...`

### 4. Styling fixes for disabled fan

![image](https://user-images.githubusercontent.com/2917861/180335087-37198232-b268-40d5-b80b-b76ba93cb58f.png)
![image](https://user-images.githubusercontent.com/2917861/180335103-32b9794a-9a08-4747-93c9-d585df8b3463.png)

