### PR TITLE
Change default dev port to avoid conflict with macOS Airplay

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ Build output should appear in the `/dist` directory.
 ### Development Inner Loop
 
 1. `npm install`
-1. Run `npm run start` to do a watch build and host the built files at `http://127.0.0.1:5000/xiaomi-fan-card.js`.
+1. Run `npm run start` to do a watch build and host the built files at `http://127.0.0.1:8234/xiaomi-fan-card.js`.
 1. On a running Home Assistant installation add this to your Lovelace
    `resources:`
 
 ```yaml
-- url: "http://127.0.0.1:5000/xiaomi-fan-card.js"
+- url: "http://127.0.0.1:8234/xiaomi-fan-card.js"
   type: module
 ```
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,34 +1,34 @@
-import devcert from 'devcert';
-import typescript from 'rollup-plugin-typescript2';
-import commonjs from 'rollup-plugin-commonjs';
-import nodeResolve from 'rollup-plugin-node-resolve';
-import babel from 'rollup-plugin-babel';
-import { terser } from 'rollup-plugin-terser';
-import serve from 'rollup-plugin-serve';
-import json from '@rollup/plugin-json';
-import ignore from './rollup-plugins/ignore';
-import { ignoreTextfieldFiles } from './elements/ignore/textfield';
-import { ignoreSelectFiles } from './elements/ignore/select';
-import { ignoreSwitchFiles } from './elements/ignore/switch';
+import devcert from "devcert";
+import typescript from "rollup-plugin-typescript2";
+import commonjs from "rollup-plugin-commonjs";
+import nodeResolve from "rollup-plugin-node-resolve";
+import babel from "rollup-plugin-babel";
+import { terser } from "rollup-plugin-terser";
+import serve from "rollup-plugin-serve";
+import json from "@rollup/plugin-json";
+import ignore from "./rollup-plugins/ignore";
+import { ignoreTextfieldFiles } from "./elements/ignore/textfield";
+import { ignoreSelectFiles } from "./elements/ignore/select";
+import { ignoreSwitchFiles } from "./elements/ignore/switch";
 
 export default async () => {
   const dev = process.env.ROLLUP_WATCH;
-  const port = process.env.PORT || 5000;
+  const port = process.env.PORT || 8234;
 
   const serveopts = {
-    contentBase: ['./dist'],
+    contentBase: ["./dist"],
     port,
     allowCrossOrigin: true,
     headers: {
-      'Access-Control-Allow-Origin': '*',
+      "Access-Control-Allow-Origin": "*",
     },
     /**
      * If your HA is running on https, resources also need to be fetched from https URLs.
      * To handle this we create and register a dev certificate when you run `npm run start -- --https`
      */
-    https: process.argv.includes("--https") ?
-      await devcert.certificateFor('localhost', { getCaPath: true }) :
-      undefined,
+    https: process.argv.includes("--https")
+      ? await devcert.certificateFor("localhost", { getCaPath: true })
+      : undefined,
   };
 
   const plugins = [
@@ -37,7 +37,7 @@ export default async () => {
     typescript(),
     json(),
     babel({
-      exclude: 'node_modules/**',
+      exclude: "node_modules/**",
     }),
     dev && serve(serveopts),
     !dev && terser(),
@@ -45,16 +45,15 @@ export default async () => {
       files: [...ignoreTextfieldFiles, ...ignoreSelectFiles, ...ignoreSwitchFiles].map((file) => require.resolve(file)),
     }),
   ];
-  
+
   return [
     {
-      input: 'src/xiaomi-fan-card.ts',
+      input: "src/xiaomi-fan-card.ts",
       output: {
-        dir: 'dist',
-        format: 'es',
+        dir: "dist",
+        format: "es",
       },
       plugins: [...plugins],
     },
   ];
-}
-
+};


### PR DESCRIPTION
I just tried developing this repo on a mac for the first time and `npm run start` fails because macOS is holding onto port 5000.

It doesn't matter to us which port is used, so I'm just changing it to `8234` as something more unique (inspired by HA's `8123`)