### PR TITLE
Fix card not refreshing

### DIFF
--- a/src/xiaomi-fan-card.ts
+++ b/src/xiaomi-fan-card.ts
@@ -453,7 +453,7 @@ export class FanXiaomiCard extends LitElement {
       return false;
     } else if (!this.isConfigureAsyncFinished && this.hass) {
       this.configureAsync();
-      return false;
+      return this.isConfigureAsyncFinished;
     }
 
     const oldHass = changedProps.get("hass") as HomeAssistant | undefined;


### PR DESCRIPTION
I'm not sure if it will work for all models but for my mifan 2 using the miio integration, the render method was not called which caused the card to not be displayed at all.